### PR TITLE
Added workflow to auto-comment on new issues

### DIFF
--- a/.github/workflows/issue-auto-reply.yml
+++ b/.github/workflows/issue-auto-reply.yml
@@ -1,0 +1,23 @@
+name: Auto Reply Bot for New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "Thank you for raising this issue! Our team will review it soon.\n\nFor more queries or discussions or approval of requests, please join the Discord server for further discussion: [Discord Link](https://discord.com/invite/Yn9g6KuWyA)"
+            })


### PR DESCRIPTION
**Summary**
This PR adds a GitHub Actions workflow that automatically comments on newly opened issues with a welcome message and a Discord link for further discussion.

**Implementation**
- Triggers on `issues.opened`
- Uses `actions/github-script`
- Sets `permissions: issues: write` to allow commenting
- Message contains the official Discord invite link

**Testing**
Tested successfully in my fork by opening a new issue — workflow ran and posted the expected comment.

Closes #9 
